### PR TITLE
Separate Nix flake ci attribute from default

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -18,4 +18,4 @@ jobs:
         uses: cachix/install-nix-action@v30
       - name: Run tests
         run: |
-          nix develop --command ./tests.bats
+          nix develop '.#ci' --command ./tests.bats

--- a/flake.nix
+++ b/flake.nix
@@ -33,17 +33,23 @@
             });
         in
         {
-          devShells.default = with pkgs;
-            mkShell {
-              buildInputs = [
-                bashInteractive
-                bats
+          devShells =
+            let
+              inherit (pkgs) bashInteractive bats mkShell;
+              ci-packages =
+                [
+                  bats
+                  bash_env_json
+                ];
+            in
+            {
+              default = mkShell { buildInputs = ci-packages ++ [ bashInteractive ]; };
 
-                bash_env_json
-              ];
+              ci = mkShell { buildInputs = ci-packages; };
+
+              packages.default = bash_env_json;
             };
 
-          packages.default = bash_env_json;
         }
       );
 }

--- a/tests/shell-functions.setup.env
+++ b/tests/shell-functions.setup.env
@@ -1,3 +1,1 @@
-unset A
-unset B
-unset C
+unset A B C


### PR DESCRIPTION
Don't need bashInteractive in CI pipeline