### PR TITLE
Fix multiline environment variables with jq -s

### DIFF
--- a/bash-env-json
+++ b/bash-env-json
@@ -22,7 +22,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-VERSION="0.10.0a1"
+VERSION="0.10.0a2"
 USAGE="bash-env-json [--help] [--shellfns <comma-separated-function-names>] [path]"
 
 shopt -s extglob
@@ -63,7 +63,7 @@ function capture() {
 function emit_value() {
     # `jq -R` produces nothing on empty input, but we want ""
     if test -n "$1"; then
-        echo -n "$1" | _jq -R
+        echo -n "$1" | _jq -Rs
     else
         echo -n '""'
     fi

--- a/nix-tests.bats
+++ b/nix-tests.bats
@@ -3,13 +3,13 @@
 # simple tests for the Nix packaging
 
 @test "simple" {
-	actual=$(echo 'export SOME_VARIABLE=some_value' | ./bash-env-json | jq -r '.env.SOME_VARIABLE')
+	actual=$(echo 'export SOME_VARIABLE=some_value' | bash-env-json | jq -r '.env.SOME_VARIABLE')
 	expected='some_value'
 	test "$actual" == "$expected"
 }
 
 @test "path" {
-	actual=$(echo 'export PATH=/oops' | ./bash-env-json | jq -r '.env.PATH')
+	actual=$(echo 'export PATH=/oops' | bash-env-json | jq -r '.env.PATH')
 	expected='/oops'
 	test "$actual" == "$expected"
 }

--- a/nix-tests.bats
+++ b/nix-tests.bats
@@ -3,13 +3,13 @@
 # simple tests for the Nix packaging
 
 @test "simple" {
-	actual=$(echo 'export SOME_VARIABLE=some_value' | bash-env-json | jq -r '.env.SOME_VARIABLE')
+	actual=$(echo 'export SOME_VARIABLE=some_value' | ./bash-env-json | jq -r '.env.SOME_VARIABLE')
 	expected='some_value'
 	test "$actual" == "$expected"
 }
 
 @test "path" {
-	actual=$(echo 'export PATH=/oops' | bash-env-json | jq -r '.env.PATH')
+	actual=$(echo 'export PATH=/oops' | ./bash-env-json | jq -r '.env.PATH')
 	expected='/oops'
 	test "$actual" == "$expected"
 }

--- a/tests.bats
+++ b/tests.bats
@@ -13,7 +13,7 @@ function test_case() {
 	echo "$@"
 
 	# sort and remove `meta` before comparison with expected output
-	bash-env-json "$@" "$_test_file" | jq --sort-keys 'del(.meta)' | diff -w - "$_expected_output"
+	./bash-env-json "$@" "$_test_file" | jq --sort-keys 'del(.meta)' | diff -w - "$_expected_output"
 }
 
 @test "empty" {
@@ -40,10 +40,13 @@ function test_case() {
 	test_case "Ming's menu of (merciless) monstrosities"
 }
 
+@test "multiline-string" {
+	test_case multiline-string
+}
+
 @test "error" {
 	test_case error
 }
-
 
 @test "shell-function-error" {
 	test_case shell-function-error --shellfns f

--- a/tests/multiline-string.env
+++ b/tests/multiline-string.env
@@ -1,0 +1,3 @@
+export MULTILINE="a
+b
+c"

--- a/tests/multiline-string.json
+++ b/tests/multiline-string.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "MULTILINE": "a\nb\nc"
+  },
+  "shellvars": { }
+}

--- a/tests/multiline-string.setup.env
+++ b/tests/multiline-string.setup.env
@@ -1,0 +1,1 @@
+unset MULTILINE


### PR DESCRIPTION
When converting raw strings to JSON.

Fixes #15